### PR TITLE
Fix tricky trait issue in fb 968

### DIFF
--- a/lib/definition-proxy.ts
+++ b/lib/definition-proxy.ts
@@ -33,7 +33,8 @@ export class DefinitionProxy {
 
 	execute(): void {
 		if (this.definition.block) {
-			this.definition.block.call(addMethodMissing(this), addMethodMissing(this));
+			const wrappedThis = addMethodMissing(this);
+			this.definition.block.call(wrappedThis, wrappedThis);
 		}
 	}
 
@@ -93,11 +94,8 @@ export class DefinitionProxy {
 	}
 
 	trait(name: string, block?: blockFunction): void {
-		if (block && isFunction(block)) {
-			this.definition.defineTrait(new Trait(name, this.fixtureRiveter, block));
-		} else {
-			throw new Error(`wrong options, bruh: ${name}, ${block}`);
-		}
+		const newTrait = new Trait(name, this.fixtureRiveter, block);
+		this.definition.defineTrait(newTrait);
 	}
 
 	transient(block: blockFunction): void {

--- a/lib/fixture-riveter.ts
+++ b/lib/fixture-riveter.ts
@@ -115,16 +115,9 @@ export class FixtureRiveter {
 		return trait;
 	}
 
-	registerTrait(trait: Trait): void {
-		for (const name of trait.names()) {
-			this.traits[name] = trait;
-		}
-	}
-
-	trait(name: string, block?: blockFunction): Trait {
+	trait(name: string, block: blockFunction): void {
 		const trait = new Trait(name, this, block);
-		this.registerTrait(trait);
-		return trait;
+		this.traits[trait.name] = trait;
 	}
 
 	sequence(

--- a/lib/fixture.ts
+++ b/lib/fixture.ts
@@ -12,6 +12,7 @@ import {
 	fixtureOptionsParser,
 } from "./fixture-options-parser";
 import {Strategy} from "./strategies/strategy";
+import {Trait} from "./trait";
 
 import {isFunction} from "lodash";
 import {Callback} from "./callback";
@@ -77,32 +78,35 @@ export class Fixture extends Definition {
 
 	compile(): void {
 		if (!this.compiled) {
-			const parentFixture = this.parentFixture();
-			parentFixture.compile();
-			for (const definedTrait of parentFixture.definedTraits) {
-				this.defineTrait(definedTrait);
-			}
+			this.parentFixture().compile();
 			super.compile();
 			this.compiled = true;
 		}
 	}
 
-	getParentAttributes(): Attribute[] {
-		const attributeNames = this.attributeNames();
-
-		return this.parentFixture()
-			.getAttributes()
-			.filter((attribute) => !attributeNames.includes(attribute.name));
+	mapTraitToThis(t: Trait): Trait {
+		t.fixture = this;
+		return t;
 	}
 
 	getAttributes(): Attribute[] {
 		this.compile();
 
-		// Need to generate child attributes before parent attributes
-		const definitionAttributes = super.getAttributes();
-		const attributesToKeep = this.getParentAttributes();
+		const attributesToKeep = this.parentFixture().getAttributes();
 
-		return attributesToKeep.concat(definitionAttributes);
+		if (!this.attributes || this.attributes.length === 0) {
+			this.attributes = [
+				this.getBaseTraits()
+					.map((t) => this.mapTraitToThis(t))
+					.map((t) => t.getAttributes()),
+				this.declarationHandler.getAttributes(),
+				this.getAdditionalTraits()
+					.map((t) => this.mapTraitToThis(t))
+					.map((t) => t.getAttributes()),
+			].flat(Infinity).filter(Boolean);
+		}
+
+		return attributesToKeep.concat(this.attributes);
 	}
 
 	getCallbacks(): Callback[] {
@@ -111,6 +115,12 @@ export class Fixture extends Definition {
 		const definedCallbacks = super.getCallbacks();
 
 		return globalCallbacks.concat(parentCallbacks, definedCallbacks);
+	}
+
+	traitByName(name: string): Trait {
+		return this.traits[name] ||
+			this.parentFixture().traitByName(name) ||
+			this.fixtureRiveter.getTrait(name);
 	}
 
 	async run(buildStrategy: Strategy, overrides: Record<string, any> = {}): Promise<any> {

--- a/lib/fixture.ts
+++ b/lib/fixture.ts
@@ -89,10 +89,14 @@ export class Fixture extends Definition {
 		return t;
 	}
 
+	getParentAttributes(): Attribute[] {
+		return this.parentFixture().getAttributes();
+	}
+
 	getAttributes(): Attribute[] {
 		this.compile();
 
-		const attributesToKeep = this.parentFixture().getAttributes();
+		const attributesToKeep = this.getParentAttributes();
 
 		if (!this.attributes || this.attributes.length === 0) {
 			this.attributes = [

--- a/lib/trait.ts
+++ b/lib/trait.ts
@@ -1,3 +1,4 @@
+import {Attribute} from "./attributes/attribute";
 import {Definition} from "./definition";
 import {DefinitionProxy} from "./definition-proxy";
 import {FixtureRiveter} from "./fixture-riveter";
@@ -5,6 +6,8 @@ import {blockFunction} from "./fixture-options-parser";
 
 /* eslint-disable class-methods-use-this */
 export class Trait extends Definition {
+	fixture: any;
+
 	constructor(
 		name: string,
 		fixtureRiveter: FixtureRiveter,
@@ -12,11 +15,32 @@ export class Trait extends Definition {
 	) {
 		super(name, fixtureRiveter);
 
-		if (block) {
-			this.block = block;
-		}
+		this.block = block;
 
 		const proxy = new DefinitionProxy(this);
 		proxy.execute();
+
+		if (proxy.childFactories.length > 0) {
+			const [factory] = proxy.childFactories;
+			throw new Error(`Can't define a factory (${factory.name}) inside trait (${this.name})`);
+		}
+	}
+
+	defineTrait(newTrait: Trait): void {
+		throw new Error(`Can't define nested traits: ${newTrait.name} inside ${this.name}`);
+	}
+
+	traitByName(name: string): Trait {
+		if (this.fixture) {
+			return this.fixture.traitByName(name);
+		}
+		return this.fixtureRiveter.getTrait(name);
+	}
+
+	getAttributes(): Attribute[] {
+		return this.aggregateFromTraitsAndSelf(
+			"getAttributes",
+			() => this.declarationHandler.getAttributes(),
+		);
 	}
 }

--- a/test/acceptance/traits.ts
+++ b/test/acceptance/traits.ts
@@ -404,3 +404,45 @@ describe("tests from fixture_bot", function() {
 		});
 	});
 });
+
+describe("#968", function() {
+	let fr: FixtureRiveter;
+	let Demo: any;
+
+	beforeEach(async function() {
+		Demo = await defineModel("Demo", {value: "string"});
+		fr = new FixtureRiveter();
+
+		fr.fixture("parent", Demo, (f: any) => {
+			f.trait("y", (t: any) => {
+				t.value(() => "parent value");
+			});
+
+			f.trait("z", (t: any) => {
+				t.y();
+			});
+
+			f.fixture("child", Demo, (ff: any) => {
+				ff.trait("y", (t: any) => {
+					t.value(() => "child value");
+				});
+			});
+		});
+	});
+
+	specify("parent first", async function() {
+		const parent = await fr.build("parent", "z");
+		const child = await fr.build("child", "z");
+
+		expect(parent.value).to.equal("parent value");
+		expect(child.value).to.equal("child value");
+	});
+
+	specify("child first", async function() {
+		const child = await fr.build("child", "z");
+		const parent = await fr.build("parent", "z");
+
+		expect(parent.value).to.equal("parent value");
+		expect(child.value).to.equal("child value");
+	});
+});

--- a/test/unit/definition-proxy.ts
+++ b/test/unit/definition-proxy.ts
@@ -140,30 +140,16 @@ describe("DefinitionProxy", function() {
 	});
 
 	describe("#trait", function() {
-		context("when given a block function", function() {
-			it("calls defineTrait", function() {
-				const fixtureRiveter = new FixtureRiveter();
-				const fixture = new Fixture(fixtureRiveter, "dummy", DummyModel);
-				const proxy = new DefinitionProxy(fixture);
-				sinon.stub(fixture, "defineTrait");
-				const name = "email";
-				const block = () => 1;
-				proxy.trait(name, block);
+		it("calls defineTrait", function() {
+			const fixtureRiveter = new FixtureRiveter();
+			const fixture = new Fixture(fixtureRiveter, "dummy", DummyModel);
+			const proxy = new DefinitionProxy(fixture);
+			sinon.stub(fixture, "defineTrait");
+			const name = "email";
+			const block = () => 1;
+			proxy.trait(name, block);
 
-				expect(fixture.defineTrait).to.be.calledOnce;
-			});
-		});
-
-		context("when given no block", function() {
-			it("throws an error", function() {
-				const fixtureRiveter = new FixtureRiveter();
-				const fixture = new Fixture(fixtureRiveter, "dummy", DummyModel);
-				const proxy = new DefinitionProxy(fixture);
-				const name = "email";
-				const fn = () => proxy.trait(name);
-
-				expect(fn).to.throw("wrong options");
-			});
+			expect(fixture.defineTrait).to.be.calledOnce;
 		});
 	});
 });

--- a/test/unit/fixture-riveter.ts
+++ b/test/unit/fixture-riveter.ts
@@ -265,43 +265,15 @@ describe("FixtureRiveter", function() {
 	});
 
 	describe("#trait", function() {
-		it("returns a new trait", function() {
-			const fr = new FixtureRiveter();
-			const result = fr.trait("email");
-
-			expect(result).to.be.an.instanceof(Trait);
-		});
-
 		it("passes both arguments through to Trait", function() {
 			const fr = new FixtureRiveter();
 			const name = "email";
 			const block = identity;
-			const result = fr.trait(name, block);
+			fr.trait(name, block);
+			const result = fr.traits[name];
 
 			expect(result.name).to.equal(name);
 			expect(result.block).to.equal(block);
-		});
-
-		it("calls registerTrait", function() {
-			const fr = new FixtureRiveter();
-			sinon.stub(fr, "registerTrait");
-			fr.trait("email");
-
-			expect(fr.registerTrait).to.be.called;
-		});
-	});
-
-	describe("#registerTrait", function() {
-		it("adds the trait for all names", function() {
-			const fr = new FixtureRiveter();
-			const name = "email";
-			const trait = new Trait(name, fr, identity);
-			sinon.stub(trait, "names").returns(["temp", name]);
-			fr.registerTrait(trait);
-
-			expect(Object.keys(fr.traits)).to.have.length(2);
-			expect(fr.traits.temp).to.equal(trait);
-			expect(fr.traits[name]).to.equal(trait);
 		});
 	});
 

--- a/test/unit/fixture.ts
+++ b/test/unit/fixture.ts
@@ -34,7 +34,7 @@ describe("Fixture", function() {
 	it("defines default options", function() {
 		const noOptions = new Fixture(fixtureRiveter, "name", DummyModel);
 		expect(noOptions.aliases).to.deep.equal([]);
-		expect(noOptions.definedTraits).to.deep.equal([]);
+		expect(noOptions.traits).to.deep.equal({});
 	});
 
 	it("accepts aliases", function() {
@@ -144,17 +144,6 @@ describe("Fixture", function() {
 			fixtureRiveter = new FixtureRiveter();
 		});
 
-		it("calls attributeNames", function() {
-			const parentFixture = new Fixture(fixtureRiveter, "parent", DummyModel);
-			const childFixture = new Fixture(fixtureRiveter, "child", DummyModel);
-			sinon.stub(childFixture, "parentFixture")
-				.returns(parentFixture);
-			sinon.spy(childFixture, "attributeNames");
-
-			childFixture.getParentAttributes();
-			expect(childFixture.attributeNames).to.be.calledOnce;
-		});
-
 		it("calls parentFixture", function() {
 			const parentFixture = new Fixture(fixtureRiveter, "parent", DummyModel);
 			const childFixture = new Fixture(fixtureRiveter, "child", DummyModel);
@@ -192,22 +181,6 @@ describe("Fixture", function() {
 
 			const result = childFixture.getParentAttributes();
 			expect(result).to.deep.equal([attr]);
-		});
-
-		it("filters existing attributes", function() {
-			const parentFixture = new Fixture(fixtureRiveter, "parent", DummyModel);
-			const attr = new DynamicAttribute("attr", false, () => true);
-			sinon.stub(parentFixture, "getAttributes")
-				.returns([attr]);
-
-			const childFixture = new Fixture(fixtureRiveter, "child", DummyModel);
-			sinon.stub(childFixture, "parentFixture")
-				.returns(parentFixture);
-			sinon.stub(childFixture, "attributeNames")
-				.returns(["attr"]);
-
-			const result = childFixture.getParentAttributes();
-			expect(result).to.deep.equal([]);
 		});
 	});
 

--- a/test/unit/trait.ts
+++ b/test/unit/trait.ts
@@ -19,7 +19,7 @@ describe("Trait", function() {
 	it("creates an instance with the correct initial values", function() {
 		const result = new Trait("trait", fixtureRiveter);
 		expect(result.attributes).to.deep.equal([]);
-		expect(result.definedTraits).to.deep.equal([]);
+		expect(result.traits).to.deep.equal({});
 	});
 
 	it("executes the given block immediately", function() {


### PR DESCRIPTION
The issue as described in [factory_bot #968][url] is that depending on the order a parent or child factory is initialized, it will copy over the other's traits in a way that leads to inconsistent results.

[url]: https://github.com/thoughtbot/factory_bot/issues/968

The fix for us (and hopefully for factory_bot, if I can present this properly) is to make the "search" for a trait happen every time instead of at compile, and to stop copying any traits at all into each other. Instead, keep track of the "parent" (which is effectively a lexical context) inside of each trait, and when calling "getAttributes" on a trait, have it check up the parent hierarchy for the existence of a trait with that name.

To handle this, we have to copy over the "parent" of each trait when iterating over them. This is slightly messy and not my favorite means of handling things, but because it happens unconditionally, it's okay.

NOTE: You have to delete or move all of the unit tests to run anything, because typescript is dumb.